### PR TITLE
Deep merging translations

### DIFF
--- a/lib/ymdp/view/application_view.rb
+++ b/lib/ymdp/view/application_view.rb
@@ -25,7 +25,9 @@ module YMDP
       @translations ||= {}
       
       Dir["./config/locales/**/*.yml"].each do |file|
-        @translations.merge!(YAML.load_file(file))
+        @translations.merge!(YAML.load_file(file)) do |key, old, new|
+          old.merge new
+        end
       end
 
       @translations


### PR DESCRIPTION
Avoids hashes being over-written if pulling from multiple YML files for a single locale
